### PR TITLE
Improve club navigation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'jquery-rails', '~> 4.3'
 gem 'simple_form', '~> 3.5'
 gem 'kaminari', '~> 1.0'
 gem 'gravatar_image_tag', '~> 1.2'
+gem 'font-awesome-rails', '~> 4.7'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
     erubi (1.6.1)
     execjs (2.7.0)
     ffi (1.9.18)
+    font-awesome-rails (4.7.0.2)
+      railties (>= 3.2, < 5.2)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     gravatar_image_tag (1.2.0)
@@ -209,6 +211,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   devise (~> 4.3)
+  font-awesome-rails (~> 4.7)
   gravatar_image_tag (~> 1.2)
   jbuilder (~> 2.5)
   jquery-rails (~> 4.3)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,7 +1,9 @@
 @import 'variables';
 @import 'bootstrap';
+@import 'font-awesome';
 @import 'overrides';
 @import 'layouts';
+@import 'clubs';
 
 body {
   height: 100%;

--- a/app/assets/stylesheets/clubs.scss
+++ b/app/assets/stylesheets/clubs.scss
@@ -1,3 +1,66 @@
 // Place all the styles related to the Clubs controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+$desaturated: desaturate(theme-color("primary"), 20%);
+$backgroundColor: mix($desaturated, white, 5%);
+$borderColor: mix($desaturated, white, 15%);
+$linkColor: theme-color("secondary");
+$hoverLinkColor: darken($linkColor, 15%);
+$hoverBorderColor: darken($borderColor, 15%);
+$activeColor: theme-color("primary");
+$activeHoverColor: darken($activeColor, 15%);
+
+.club-header {
+  background-color: $backgroundColor;
+  border-bottom: 1px solid $borderColor;
+  margin-top: -1.5rem;
+  padding-top: 1.5rem;
+}
+
+.club-nav {
+  border-bottom: 1px solid $borderColor;
+
+  .nav-link {
+    padding: 1rem 0.5rem;
+    margin-right: 1rem;
+    color: $linkColor;
+    margin-bottom: -1px;
+    border-bottom: 1px solid $borderColor;
+
+    .badge {
+      background-color: $linkColor;
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
+      color: $hoverLinkColor;
+      border-bottom-color: $hoverBorderColor;
+
+      .badge {
+        background-color: $hoverLinkColor;
+      }
+    }
+  }
+
+  .active {
+    border-bottom: 1px solid $activeColor;
+    margin-bottom: -1px;
+    color: $activeColor;
+
+    .badge {
+      background-color: $activeColor;
+    }
+
+    &:active,
+    &:hover,
+    &:focus {
+      color: $activeHoverColor;
+      border-bottom-color: $activeHoverColor;
+
+      .badge {
+        background-color: $activeHoverColor;
+      }
+    }
+  }
+}

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -67,10 +67,7 @@ class ClubsController < ApplicationController
   # POST /clubs/1/join.json
   def join
     @club = Club.find(params[:id])
-    ClubMembership.create({
-      user_id: current_user.id,
-      club_id: @club.id
-    })
+    @club.club_memberships.create! user_id: current_user.id
     redirect_to action: :show
   end
 
@@ -78,10 +75,7 @@ class ClubsController < ApplicationController
   # POST /clubs/1/leave.json
   def leave
     @club = Club.find(params[:id])
-    ClubMembership.where({
-      user_id: current_user.id,
-      club_id: @club.id
-    }).destroy_all
+    @club.club_memberships.where(user_id: current_user).destroy_all
     redirect_to action: :show
   end
 

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -9,7 +9,6 @@ class ClubsController < ApplicationController
   # GET /clubs/1.json
   def show
     @club = Club.find(params[:id])
-    @container = false
   end
 
   # GET /clubs/new
@@ -20,7 +19,6 @@ class ClubsController < ApplicationController
   # GET /clubs/1/edit
   def edit
     @club = Club.find(params[:id])
-    @container = false
   end
 
   # POST /clubs
@@ -84,13 +82,11 @@ class ClubsController < ApplicationController
   # GET /clubs/1/members
   def members
     @club = Club.find(params[:id])
-    @container = false
   end
 
   # GET /clubs/1/membership
   def membership
     @club = Club.find(params[:id])
-    @container = false
   end
 
   private

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -9,6 +9,7 @@ class ClubsController < ApplicationController
   # GET /clubs/1.json
   def show
     @club = Club.find(params[:id])
+    @container = false
   end
 
   # GET /clubs/new
@@ -19,6 +20,7 @@ class ClubsController < ApplicationController
   # GET /clubs/1/edit
   def edit
     @club = Club.find(params[:id])
+    @container = false
   end
 
   # POST /clubs
@@ -82,11 +84,13 @@ class ClubsController < ApplicationController
   # GET /clubs/1/members
   def members
     @club = Club.find(params[:id])
+    @container = false
   end
 
   # GET /clubs/1/membership
   def membership
     @club = Club.find(params[:id])
+    @container = false
   end
 
   private

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -2,7 +2,7 @@ class WelcomeController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    if current_user.has_no_clubs
+    if current_user.has_no_clubs?
       redirect_to "/clubs"
     end
   end

--- a/app/models/club_membership.rb
+++ b/app/models/club_membership.rb
@@ -1,8 +1,4 @@
 class ClubMembership < ApplicationRecord
   belongs_to :user
   belongs_to :club
-
-  def created_at
-    @created_at
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,19 +12,16 @@ class User < ApplicationRecord
     full_name
   end
 
-  def has_no_clubs
+  def has_no_clubs?
     clubs.length == 0
   end
 
-  def is_member_of club
+  def is_member_of? club
     clubs.exists?(club.id)
   end
 
   def member_since club
-    membership = ClubMembership.where({
-      user_id: id,
-      club_id: club.id
-    }).first
+    membership = club_memberships.where(club_id: club.id).first
     membership.updated_at unless membership == nil
   end
 end

--- a/app/views/birds/edit.html.erb
+++ b/app/views/birds/edit.html.erb
@@ -1,6 +1,8 @@
-<h1>Editing Bird</h1>
+<div class="container">
+  <h1>Editing Bird</h1>
 
-<%= render 'form', bird: @bird %>
+  <%= render 'form', bird: @bird %>
 
-<%= link_to 'Show', @bird %> |
-<%= link_to 'Back', birds_path %>
+  <%= link_to 'Show', @bird %> |
+  <%= link_to 'Back', birds_path %>
+</div>

--- a/app/views/birds/index.html.erb
+++ b/app/views/birds/index.html.erb
@@ -1,47 +1,49 @@
-<div class="row">
-  <div class="col">
-    <h1>Birds</h1>
-    <%= link_to 'New Bird', new_bird_path, class: 'btn btn-outline-primary mb-3' %>
+<div class="container">
+  <div class="row">
+    <div class="col">
+      <h1>Birds</h1>
+      <%= link_to 'New Bird', new_bird_path, class: 'btn btn-outline-primary mb-3' %>
+    </div>
   </div>
-</div>
 
-<div class="row">
-  <div class="col">
-    <table class="table table-bordered">
-      <thead>
-        <tr>
-          <th>Common name</th>
-          <th>Scientific name</th>
-          <th>Order</th>
-          <th>Scientific family name</th>
-          <th>Common family name</th>
-          <th>Sort position</th>
-          <th>Species</th>
-          <th colspan="3">Actions</th>
-        </tr>
-      </thead>
-
-      <tbody>
-        <% @birds.each do |bird| %>
+  <div class="row">
+    <div class="col">
+      <table class="table table-bordered">
+        <thead>
           <tr>
-            <td><%= bird.common_name %></td>
-            <td><%= bird.scientific_name %></td>
-            <td><%= bird.order %></td>
-            <td><%= bird.scientific_family_name %></td>
-            <td><%= bird.common_family_name %></td>
-            <td><%= bird.sort_position %></td>
-            <td><%= bird.species_id %></td>
-            <td><%= link_to 'Show', bird %></td>
-            <td><%= link_to 'Edit', edit_bird_path(bird) %></td>
-            <td><%= link_to 'Destroy', bird, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            <th>Common name</th>
+            <th>Scientific name</th>
+            <th>Order</th>
+            <th>Scientific family name</th>
+            <th>Common family name</th>
+            <th>Sort position</th>
+            <th>Species</th>
+            <th colspan="3">Actions</th>
           </tr>
-        <% end %>
-      </tbody>
-    </table>
+        </thead>
+
+        <tbody>
+          <% @birds.each do |bird| %>
+            <tr>
+              <td><%= bird.common_name %></td>
+              <td><%= bird.scientific_name %></td>
+              <td><%= bird.order %></td>
+              <td><%= bird.scientific_family_name %></td>
+              <td><%= bird.common_family_name %></td>
+              <td><%= bird.sort_position %></td>
+              <td><%= bird.species_id %></td>
+              <td><%= link_to 'Show', bird %></td>
+              <td><%= link_to 'Edit', edit_bird_path(bird) %></td>
+              <td><%= link_to 'Destroy', bird, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
-</div>
-<div class="row">
-  <div class="col">
-    <%= paginate @birds %>
+  <div class="row">
+    <div class="col">
+      <%= paginate @birds %>
+    </div>
   </div>
 </div>

--- a/app/views/birds/new.html.erb
+++ b/app/views/birds/new.html.erb
@@ -1,9 +1,11 @@
-<div class="row">
-  <div class="col-12">
-    <h1>New Bird</h1>
-  </div>
-  <%= render 'form', bird: @bird %>
-  <div class="col-12">
-  <%= link_to 'Back', birds_path %>
+<div class="container">
+  <div class="row">
+    <div class="col-12">
+      <h1>New Bird</h1>
+    </div>
+    <%= render 'form', bird: @bird %>
+    <div class="col-12">
+    <%= link_to 'Back', birds_path %>
+    </div>
   </div>
 </div>

--- a/app/views/birds/show.html.erb
+++ b/app/views/birds/show.html.erb
@@ -1,39 +1,41 @@
-<p id="notice"><%= notice %></p>
+<div class="container">
+  <p id="notice"><%= notice %></p>
 
-<p>
-  <strong>Common name:</strong>
-  <%= @bird.common_name %>
-</p>
+  <p>
+    <strong>Common name:</strong>
+    <%= @bird.common_name %>
+  </p>
 
-<p>
-  <strong>Scientific name:</strong>
-  <%= @bird.scientific_name %>
-</p>
+  <p>
+    <strong>Scientific name:</strong>
+    <%= @bird.scientific_name %>
+  </p>
 
-<p>
-  <strong>Order:</strong>
-  <%= @bird.order %>
-</p>
+  <p>
+    <strong>Order:</strong>
+    <%= @bird.order %>
+  </p>
 
-<p>
-  <strong>Scientific family name:</strong>
-  <%= @bird.scientific_family_name %>
-</p>
+  <p>
+    <strong>Scientific family name:</strong>
+    <%= @bird.scientific_family_name %>
+  </p>
 
-<p>
-  <strong>Common family name:</strong>
-  <%= @bird.common_family_name %>
-</p>
+  <p>
+    <strong>Common family name:</strong>
+    <%= @bird.common_family_name %>
+  </p>
 
-<p>
-  <strong>Sort position:</strong>
-  <%= @bird.sort_position %>
-</p>
+  <p>
+    <strong>Sort position:</strong>
+    <%= @bird.sort_position %>
+  </p>
 
-<p>
-  <strong>Species:</strong>
-  <%= @bird.species_id %>
-</p>
+  <p>
+    <strong>Species:</strong>
+    <%= @bird.species_id %>
+  </p>
 
-<%= link_to 'Edit', edit_bird_path(@bird) %> |
-<%= link_to 'Back', birds_path %>
+  <%= link_to 'Edit', edit_bird_path(@bird) %> |
+  <%= link_to 'Back', birds_path %>
+</div>

--- a/app/views/clubs/_card.html.erb
+++ b/app/views/clubs/_card.html.erb
@@ -5,7 +5,7 @@
       <h6 class="card-subtitle mb-2 text-muted"><%= club.name %></h6>
     <% end %>
     <p class="card-text"><%= club.description %></p>
-    <% if current_user.is_member_of(club) %>
+    <% if current_user.is_member_of?(club) %>
       <%= link_to "Member", club_path(club), class: "btn btn-outline-success" %>
     <% else %>
       <%= button_to "Join", join_club_path(club), class: "btn btn-primary" %>

--- a/app/views/clubs/_header.html.erb
+++ b/app/views/clubs/_header.html.erb
@@ -1,11 +1,15 @@
-<% if current_user.is_member_of?(@club) %>
-  <%= link_to 'Member', club_membership_path(@club), class: 'btn btn-outline-success float-right' %>
-<% else %>
-  <%= button_to 'Join', join_club_path(@club), class: 'btn btn-outline-primary float-right' %>
-<% end %>
+<div class="club-header">
+  <div class="container">
+    <% if current_user.is_member_of?(@club) %>
+      <%= link_to 'Member', club_membership_path(@club), class: 'btn btn-outline-success float-right' %>
+    <% else %>
+      <%= button_to 'Join', join_club_path(@club), class: 'btn btn-outline-primary float-right' %>
+    <% end %>
 
-<h1 class="mt-4"><%= @club.display_name %></h1>
+    <h1><%= @club.display_name %></h1>
 
-<% if @club.has_short_name %>
-  <p class="lead"><%= @club.name %></p>
-<% end %>
+    <% if @club.has_short_name %>
+      <p class="lead"><%= @club.name %></p>
+    <% end %>
+  </div>
+</div>

--- a/app/views/clubs/_header.html.erb
+++ b/app/views/clubs/_header.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.is_member_of(@club) %>
+<% if current_user.is_member_of?(@club) %>
   <%= link_to 'Member', club_membership_path(@club), class: 'btn btn-outline-success float-right' %>
 <% else %>
   <%= button_to 'Join', join_club_path(@club), class: 'btn btn-outline-primary float-right' %>

--- a/app/views/clubs/_nav.html.erb
+++ b/app/views/clubs/_nav.html.erb
@@ -7,7 +7,7 @@
       Members <span class="badge badge-secondary"><%= @club.members.length %></span>
     <% end %>
   </li>
-  <% if current_user.is_member_of(@club) %>
+  <% if current_user.is_member_of?(@club) %>
   <li class="nav-item">
     <%= link_to 'Membership', club_membership_path(@club), class: nav_link_class(club_membership_path(@club)) %>
   </li>

--- a/app/views/clubs/_nav.html.erb
+++ b/app/views/clubs/_nav.html.erb
@@ -1,18 +1,33 @@
-<ul class="nav nav-tabs">
-  <li class="nav-item">
-    <%= link_to 'Overview', club_path(@club), class: nav_link_class(club_path(@club)) %>
-  </li>
-  <li class="nav-item">
-    <%= link_to club_members_path(@club), class: nav_link_class(club_members_path(@club)) do %>
-      Members <span class="badge badge-secondary"><%= @club.members.length %></span>
-    <% end %>
-  </li>
-  <% if current_user.is_member_of?(@club) %>
-  <li class="nav-item">
-    <%= link_to 'Membership', club_membership_path(@club), class: nav_link_class(club_membership_path(@club)) %>
-  </li>
-  <% end %>
-  <li class="nav-item">
-    <%= link_to 'Settings', edit_club_path(@club), class: nav_link_class(edit_club_path(@club)) %>
-  </li>
-</ul>
+<nav class="club-nav">
+  <div class="container">
+    <ul class="nav justify-content-center justify-content-sm-start">
+      <li class="nav-item">
+        <%= link_to club_path(@club), class: nav_link_class(club_path(@club)) do %>
+          <span class="d-none d-sm-inline">Overview</span>
+          <span class="d-sm-none"><%= fa_icon 'home' %></span>
+        <% end %>
+      </li>
+      <li class="nav-item">
+        <%= link_to club_members_path(@club), class: nav_link_class(club_members_path(@club)) do %>
+          <span class="d-none d-sm-inline">Members</span>
+          <span class="d-sm-none"><%= fa_icon 'users' %></span>
+          <span class="badge"><%= @club.members.length %></span>
+        <% end %>
+      </li>
+      <% if current_user.is_member_of?(@club) %>
+      <li class="nav-item">
+        <%= link_to club_membership_path(@club), class: nav_link_class(club_membership_path(@club)) do %>
+          <span class="d-none d-sm-inline">Membership</span>
+          <span class="d-sm-none"><%= fa_icon 'user' %></span>
+        <% end %>
+      </li>
+      <% end %>
+      <li class="nav-item">
+        <%= link_to edit_club_path(@club), class: nav_link_class(edit_club_path(@club)) do %>
+          <span class="d-none d-sm-inline">Settings</span>
+          <span class="d-sm-none"><%= fa_icon 'cog' %></span>
+        <% end %>
+      </li>
+    </ul>
+  </div>
+</nav>

--- a/app/views/clubs/edit.html.erb
+++ b/app/views/clubs/edit.html.erb
@@ -1,3 +1,6 @@
 <%= render 'header' %>
 <%= render 'nav' %>
+
+<div class="container">
 <%= render 'form' %>
+</div>

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="mt-4">Clubs</h1>
-<% if current_user.has_no_clubs %>
+<% if current_user.has_no_clubs? %>
   <p class="lead">Join a club to get started with Birdr</p>
 <% end %>
 

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,12 +1,14 @@
-<h1 class="mt-4">Clubs</h1>
-<% if current_user.has_no_clubs? %>
-  <p class="lead">Join a club to get started with Birdr</p>
-<% end %>
-
-<div class="mt-4 mb-4">
-  <% @clubs.each do |club| %>
-    <%= render 'card', club: club %>
+<div class="container">
+  <h1>Clubs</h1>
+  <% if current_user.has_no_clubs? %>
+    <p class="lead">Join a club to get started with Birdr</p>
   <% end %>
-</div>
 
-<%= button_to "Create a Club", new_club_path, method: :get, class: "btn btn-outline-primary mb-4" %>
+  <div class="mt-4 mb-4">
+    <% @clubs.each do |club| %>
+      <%= render 'card', club: club %>
+    <% end %>
+  </div>
+
+  <%= button_to "Create a Club", new_club_path, method: :get, class: "btn btn-outline-primary mb-4" %>
+</div>

--- a/app/views/clubs/members.erb
+++ b/app/views/clubs/members.erb
@@ -1,19 +1,21 @@
 <%= render 'header' %>
 <%= render 'nav' %>
 
-<table class="table table-stiped mt-4">
-  <thead>
-    <tr>
-      <th>Name</th>
-      <th>Member since</th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @club.members.each do |member| %>
-    <tr>
-      <td><%= member.full_name %></td>
-      <td><%= member.member_since(@club).strftime("%d-%m-%Y") %></td>
-    </tr>
-    <% end %>
-  </tbody>
-</table>
+<div class="container">
+  <table class="table table-stiped mt-4">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Member since</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @club.members.each do |member| %>
+      <tr>
+        <td><%= member.full_name %></td>
+        <td><%= member.member_since(@club).strftime("%d-%m-%Y") %></td>
+      </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/clubs/membership.erb
+++ b/app/views/clubs/membership.erb
@@ -3,7 +3,7 @@
 
 <div class="row mt-4">
   <div class="col-md-6">
-    <% if current_user.is_member_of(@club) %>
+    <% if current_user.is_member_of?(@club) %>
       <h4>You're a member</h4>
       <p>You've been a member of <%= @club.display_name %> since <%= current_user.member_since(@club).strftime("%d-%m-%Y") %>.</p>
       <%= button_to "Leave #{@club.display_name}", leave_club_path(@club), class: 'btn btn-outline-danger' %>

--- a/app/views/clubs/membership.erb
+++ b/app/views/clubs/membership.erb
@@ -1,12 +1,14 @@
 <%= render 'header' %>
 <%= render 'nav' %>
 
-<div class="row mt-4">
-  <div class="col-md-6">
-    <% if current_user.is_member_of?(@club) %>
-      <h4>You're a member</h4>
-      <p>You've been a member of <%= @club.display_name %> since <%= current_user.member_since(@club).strftime("%d-%m-%Y") %>.</p>
-      <%= button_to "Leave #{@club.display_name}", leave_club_path(@club), class: 'btn btn-outline-danger' %>
-    <% end %>
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-md-6">
+      <% if current_user.is_member_of?(@club) %>
+        <h4>You're a member</h4>
+        <p>You've been a member of <%= @club.display_name %> since <%= current_user.member_since(@club).strftime("%d-%m-%Y") %>.</p>
+        <%= button_to "Leave #{@club.display_name}", leave_club_path(@club), class: 'btn btn-outline-danger' %>
+      <% end %>
+    </div>
   </div>
 </div>

--- a/app/views/clubs/new.html.erb
+++ b/app/views/clubs/new.html.erb
@@ -1,5 +1,7 @@
-<h1>New Club</h1>
+<div class="container">
+  <h1>New Club</h1>
 
-<%= render 'form', club: @club %>
+  <%= render 'form', club: @club %>
 
-<%= link_to 'Back', clubs_path %>
+  <%= link_to 'Back', clubs_path %>
+</div>

--- a/app/views/clubs/show.html.erb
+++ b/app/views/clubs/show.html.erb
@@ -1,9 +1,11 @@
 <%= render 'header' %>
 <%= render 'nav' %>
 
-<div class="row mt-4">
-  <div class="col-md-6 mb-3">
-    <h4>About the club</h4>
-    <%= @club.description %>
+<div class="container">
+  <div class="row mt-4">
+    <div class="col-md-6 mb-3">
+      <h4>About the club</h4>
+      <%= @club.description %>
+    </div>
   </div>
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,8 @@
 
   <body>
     <%= render 'layouts/navigation' %>
-    <div class="container">
+    <% if @container != false %><div class="container"><% end %>
     <%= yield %>
-    </div>
+    <% if @container != false %></div><% end %>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,8 +10,6 @@
 
   <body>
     <%= render 'layouts/navigation' %>
-    <% if @container != false %><div class="container"><% end %>
     <%= yield %>
-    <% if @container != false %></div><% end %>
   </body>
 </html>

--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,1 +1,3 @@
-<h1 class="mt-4">Welcome</h1>
+<div class="container">
+  <h1>Welcome</h1>
+</div>


### PR DESCRIPTION
* This PR jazzes up the club navigation
* We could probably reuse this secondary nav in other places when we need it
* I've removed the `.container` in the main layout to support the full width elements here and replaced it in the individual templates
* Also addresses some of the comments in the last PR

<img src="https://user-images.githubusercontent.com/917111/29750899-dd783d18-8b3f-11e7-93f1-b2db53587d72.png" width="300"/>

![localhost-3000-clubs-2 ipad 1](https://user-images.githubusercontent.com/917111/29750904-e1be1a0a-8b3f-11e7-9854-5a7b76059de1.png)
